### PR TITLE
Deploy

### DIFF
--- a/.github/workflows/ghpages-deployment.yml
+++ b/.github/workflows/ghpages-deployment.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - deploy
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm --prefix packages/web run build
+
+          touch packages/web/dist/.nojekyll
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.7.2
+        with:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: packages/web/dist

--- a/.github/workflows/ghpages-deployment.yml
+++ b/.github/workflows/ghpages-deployment.yml
@@ -15,6 +15,8 @@ jobs:
         run: |
           npm install
           npm --prefix packages/web run build
+          mkdir packages/web/dist/app
+          cp packages/web/dist/* packages/web/dist/app
 
           touch packages/web/dist/.nojekyll
       - name: Deploy 🚀

--- a/.github/workflows/ghpages-deployment.yml
+++ b/.github/workflows/ghpages-deployment.yml
@@ -16,7 +16,7 @@ jobs:
           npm install
           npm --prefix packages/web run build
           mkdir packages/web/dist/app
-          cp packages/web/dist/* packages/web/dist/app
+          rsync -av --exclude='app/' packages/web/dist/ packages/web/dist/app/
 
           touch packages/web/dist/.nojekyll
       - name: Deploy 🚀

--- a/packages/core/components/FileDetails/index.tsx
+++ b/packages/core/components/FileDetails/index.tsx
@@ -13,7 +13,7 @@ import { ROOT_ELEMENT_ID } from "../../App";
 import FileThumbnail from "../../components/FileThumbnail";
 import AnnotationName from "../../entity/Annotation/AnnotationName";
 import annotationFormatterFactory, { AnnotationType } from "../../entity/AnnotationFormatter";
-import useOpenWithMenuItems from "../../hooks/useOpenWithMenuItems";
+// import useOpenWithMenuItems from "../../hooks/useOpenWithMenuItems";
 import { MAX_DOWNLOAD_SIZE_WEB } from "../../services/FileDownloadService";
 import { interaction } from "../../state";
 
@@ -115,8 +115,11 @@ export default function FileDetails(props: Props) {
                         .canUseDirectoryArguments(fileDetails.path)
                         .then((canUse) => {
                             if (!canUse) return;
-                            const { hostname, bucket, key } =
-                                fileDownloadService.parseVirtualizedUrl(fileDetails.path);
+                            const {
+                                hostname,
+                                bucket,
+                                key,
+                            } = fileDownloadService.parseVirtualizedUrl(fileDetails.path);
                             fileDownloadService
                                 .calculateS3DirectorySize(hostname, key, bucket)
                                 .then(setCalculatedSize);
@@ -127,7 +130,7 @@ export default function FileDetails(props: Props) {
     }, [fileDetails, fileDownloadService, isOnWeb, isZarr]);
 
     const processStatuses = useSelector(interaction.selectors.getProcessStatuses);
-    const openWithMenuItems = useOpenWithMenuItems(fileDetails || undefined);
+    // const openWithMenuItems = useOpenWithMenuItems(fileDetails || undefined);
 
     // Disable download of large Zarrs ( > 2GB).
     const isDownloadDisabled = fileDetails
@@ -217,15 +220,14 @@ export default function FileDetails(props: Props) {
                                     <Tooltip content={downloadDisabledMessage}>
                                         <PrimaryButton
                                             className={styles.primaryButton}
-                                            disabled={isDownloadDisabled}
-                                            iconName="Download"
-                                            text="Download"
-                                            title="Download file to local system"
+                                            iconName="OpenInNewWindow"
+                                            text="Open Image in IDR"
+                                            title="Open Image viewer in IDR"
                                             onClick={onDownload}
                                         />
                                     </Tooltip>
                                 </StackItem>
-                                <StackItem>
+                                {/* <StackItem>
                                     <PrimaryButton
                                         className={styles.primaryButton}
                                         iconName="OpenInNewWindow"
@@ -233,7 +235,7 @@ export default function FileDetails(props: Props) {
                                         title="Open file by selected method"
                                         menuItems={openWithMenuItems}
                                     />
-                                </StackItem>
+                                </StackItem> */}
                             </Stack>
                             <p className={styles.fileName}>{fileDetails?.name}</p>
                             <h4>Information</h4>

--- a/packages/web/src/components/Header/Menu.tsx
+++ b/packages/web/src/components/Header/Menu.tsx
@@ -29,22 +29,22 @@ export default function Menu() {
     return (
         <>
             <div className={classNames(styles.right, styles.largeMenu)}>
-                <Link
-                    to="datasets"
+                <a
+                    href="https://bff.allencell.org/datasets"
                     className={styles.routeLink}
                     target={isApp ? "_blank" : "_self"}
                     rel="noreferrer"
                 >
                     Open-source datasets
-                </Link>
-                <Link
-                    to="learn"
+                </a>
+                <a
+                    href="https://bff.allencell.org/learn"
                     className={styles.routeLink}
                     target={isApp ? "_blank" : "_self"}
                     rel="noreferrer"
                 >
                     Learn
-                </Link>
+                </a>
                 <PrimaryButton
                     ariaLabel="Help"
                     className={styles.helpMenuButton}

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -50,7 +50,7 @@ const router = createBrowserRouter(
         },
     ],
     {
-        basename: "",
+        basename: "https://will-moore.github.io/biofile-finder",
     }
 );
 

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter(
             element: <Layout />,
             children: [
                 {
-                    path: "/",
+                    path: "home",
                     element: <Home />, // Splash page
                 },
                 {
@@ -39,7 +39,7 @@ const router = createBrowserRouter(
                     element: <Learn />,
                 },
                 {
-                    path: "app",
+                    path: "/", // make the APP the home page
                     element: <FmsFileExplorer className={styles.app} />,
                 },
                 {

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -50,7 +50,7 @@ const router = createBrowserRouter(
         },
     ],
     {
-        basename: "https://will-moore.github.io/biofile-finder",
+        basename: "/biofile-finder",
     }
 );
 

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -50,7 +50,8 @@ const router = createBrowserRouter(
         },
     ],
     {
-        basename: "/biofile-finder",
+        // If we're hosted in a GitHub Pages site, we need to set the basename to the repo name
+        basename: process.env.GITHUB_REPOSITORY_OWNER ? "/biofile-finder" : "",
     }
 );
 

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -31,7 +31,7 @@ const router = createBrowserRouter(
             element: <Layout />,
             children: [
                 {
-                    path: "home",
+                    path: "/",
                     element: <Home />, // Splash page
                 },
                 {
@@ -39,7 +39,7 @@ const router = createBrowserRouter(
                     element: <Learn />,
                 },
                 {
-                    path: "/", // make the APP the home page
+                    path: "app",
                     element: <FmsFileExplorer className={styles.app} />,
                 },
                 {


### PR DESCRIPTION
Deploy BFF with GitHub pages...

Deployed at https://will-moore.github.io/biofile-finder/app

NB: this is deployed from the `deploy` branch (for this PR). But we may want to choose a different branch?
The app is built and pushed to `gh-pages` branch. Enabled gh-pages to deploy from that branch.

We duplicate the static app to handle serving from https://will-moore.github.io/biofile-finder/ AND https://will-moore.github.io/biofile-finder/app. 
Other links from the app header have been hard-coded to https://bff.allencell.org/datasets and https://bff.allencell.org/learn.

Custom IDR change: The right panel has "OPEN IMAGE IN IDR" link instead of confusing "DOWNLOAD".